### PR TITLE
Improve mock support for AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ custom:
       port: 1884
     # Uncomment only if you already have an MQTT server running locally
     # noStart: true
+      redisHost: 'localhost'
+      redisPort: 6379
+      redisDB: 12
 ```
 
 ### Using with serverless-offline plugin

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ custom:
       port: 1884
     # Uncomment only if you already have an MQTT server running locally
     # noStart: true
-      redis:
-        host: 'localhost'
-        port: 6379
-        db: 12
+    redis:
+      host: 'localhost'
+      port: 6379
+      db: 12
 ```
 
 ### Using with serverless-offline plugin

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ custom:
       port: 1884
     # Uncomment only if you already have an MQTT server running locally
     # noStart: true
-      redisHost: 'localhost'
-      redisPort: 6379
-      redisDB: 12
+      redis:
+        host: 'localhost'
+        port: 6379
+        db: 12
 ```
 
 ### Using with serverless-offline plugin

--- a/broker.js
+++ b/broker.js
@@ -1,21 +1,5 @@
 const mosca = require('mosca')
 const redis = require('redis')
-const ascoltatore = {
-  type: 'redis',
-  redis,
-  db: 12,
-  port: 6379,
-  return_buffers: true, // to handle binary payloads
-  host: 'localhost'
-}
-
-const moscaSettings = {
-  // port: 1883,
-  backend: ascoltatore,
-  persistence: {
-    factory: mosca.persistence.Redis
-  }
-}
 
 // fired when the mqtt server is ready
 function setup() {
@@ -40,6 +24,25 @@ function createAWSLifecycleEvent ({ type, clientId, topics }) {
 }
 
 function createBroker (opts) {
+  const { redisHost, redisPort, redisDB } = opts
+
+  const ascoltatore = {
+    type: 'redis',
+    redis,
+    host: redisHost,
+    port: redisPort,
+    db: redisDB,
+    return_buffers: true // to handle binary payloads
+  }
+
+  const moscaSettings = {
+    // port: 1883,
+    backend: ascoltatore,
+    persistence: {
+    factory: mosca.persistence.Redis
+    }
+  }
+
   opts = Object.assign({}, moscaSettings, opts)
   const server = new mosca.Server(opts)
   server.on('ready', setup)

--- a/broker.js
+++ b/broker.js
@@ -23,7 +23,13 @@ function createAWSLifecycleEvent ({ type, clientId, topics }) {
   return event
 }
 
-function createBroker (opts) {
+/**
+ * https://github.com/aws/aws-sdk-js/blob/master/clients/iot.d.ts#L349
+ * 
+ * @param {Object} opts Module options
+ * @param {Object} moscaOpts Mosca options
+ */
+function createBroker (opts, moscaOpts) {
   const { redisHost, redisPort, redisDB } = opts
 
   const ascoltatore = {
@@ -39,12 +45,12 @@ function createBroker (opts) {
     // port: 1883,
     backend: ascoltatore,
     persistence: {
-    factory: mosca.persistence.Redis
+      factory: mosca.persistence.Redis
     }
   }
 
-  opts = Object.assign({}, moscaSettings, opts)
-  const server = new mosca.Server(opts)
+  moscaOpts = Object.assign({}, moscaSettings, moscaOpts)
+  const server = new mosca.Server(moscaOpts)
   server.on('ready', setup)
 
   // fired when a message is received

--- a/broker.js
+++ b/broker.js
@@ -1,5 +1,4 @@
 const mosca = require('mosca')
-const redis = require('redis')
 
 // fired when the mqtt server is ready
 function setup() {
@@ -29,18 +28,7 @@ function createAWSLifecycleEvent ({ type, clientId, topics }) {
  * @param {Object} opts Module options
  * @param {Object} moscaOpts Mosca options
  */
-function createBroker (opts, moscaOpts) {
-  const { redisHost, redisPort, redisDB } = opts
-
-  const ascoltatore = {
-    type: 'redis',
-    redis,
-    host: redisHost,
-    port: redisPort,
-    db: redisDB,
-    return_buffers: true // to handle binary payloads
-  }
-
+function createBroker (ascoltatore, moscaOpts) {
   const moscaSettings = {
     // port: 1883,
     backend: ascoltatore,

--- a/index.js
+++ b/index.js
@@ -152,35 +152,6 @@ class ServerlessIotLocal {
       })
     })
 
-    AWS.mock('STS', 'getCallerIdentity', (params, callback) => {
-      process.nextTick(() => {
-        callback(null, { 
-            ResponseMetadata: { RequestId: `offlineContext_requestId_${_.random()}` },
-            UserId: 'offlineContext_userId',
-            Account: 'offlineContext_accountId',
-            Arn: 'arn:aws:sts::offlineContext_accountId:assumed-role/LambdaExecution/offlineContext_caller'
-        })
-      })
-    })
-
-    AWS.mock('STS', 'assumeRole', (params, callback) => {
-      process.nextTick(() => {
-        callback(null, { 
-            ResponseMetadata: { RequestId: `offlineContext_requestId_${_.random()}` },
-            Credentials: { 
-                AccessKeyId: 'offlineContext_accessKeyId',
-                SecretAccessKey: 'offlineContext_secretAccessKey',
-                SessionToken: 'offlineContext_sessionToken',
-                Expiration: new Date()
-            },
-            AssumedRoleUser: {
-                AssumedRoleId: 'offlineContext_assumedRoleId',
-                Arn: 'arn:aws:sts::offlineContext_accountId:assumed-role/LambdaExecution/offlineContext_caller'
-            }
-        })
-      })
-    })
-
     this.log(`Iot broker listening on ports: ${port} (mqtt) and ${httpPort} (http)`)
   }
 

--- a/index.js
+++ b/index.js
@@ -109,19 +109,26 @@ class ServerlessIotLocal {
   }
 
   _createMQTTBroker() {
-    const { host, port, httpPort, redisHost, redisPort, redisDB } = this.options
-    this.mqttBroker = createMQTTBroker({
+    const { host, port, httpPort } = this.options
+    const { redisHost, redisPort, redisDB } = this.options
+
+    const ascoltatore = {
+      redisHost,
+      redisPort,
+      redisDB
+    }
+
+    const mosca = {
       host,
       port,
       http: {
         host,
         port: httpPort,
         bundle: true
-      },
-      redisHost,
-      redisPort,
-      redisDB
-    })
+      }
+    }
+
+    this.mqttBroker = createMQTTBroker(ascoltatore, mosca)
 
     const endpointAddress = `${IP.address()}:${httpPort}`
 
@@ -140,7 +147,8 @@ class ServerlessIotLocal {
 
     AWS.mock('Iot', 'describeEndpoint', (params, callback) => {
       process.nextTick(() => {
-        callback(null, { endpointAddress })
+        // Parameter params is optional.
+        (callback || params)(null, { endpointAddress })
       })
     })
 

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ class ServerlessIotLocal {
       this.mqttBroker.publish({ topic, payload }, callback)
     })
 
-    AWS.mock('Iot', 'describeEndpoint', callback => {
+    AWS.mock('Iot', 'describeEndpoint', (params, callback) => {
       process.nextTick(() => {
         callback(null, { endpointAddress })
       })

--- a/index.js
+++ b/index.js
@@ -129,6 +129,35 @@ class ServerlessIotLocal {
       })
     })
 
+    AWS.mock('STS', 'getCallerIdentity', (params, callback) => {
+      process.nextTick(() => {
+        callback(null, { 
+            ResponseMetadata: { RequestId: `offlineContext_requestId_${_.random()}` },
+            UserId: 'offlineContext_userId',
+            Account: 'offlineContext_accountId',
+            Arn: 'arn:aws:sts::offlineContext_accountId:assumed-role/LambdaExecution/offlineContext_caller'
+        })
+      })
+    })
+
+    AWS.mock('STS', 'assumeRole', (params, callback) => {
+      process.nextTick(() => {
+        callback(null, { 
+            ResponseMetadata: { RequestId: `offlineContext_requestId_${_.random()}` },
+            Credentials: { 
+                AccessKeyId: 'offlineContext_accessKeyId',
+                SecretAccessKey: 'offlineContext_secretAccessKey',
+                SessionToken: 'offlineContext_sessionToken',
+                Expiration: new Date()
+            },
+            AssumedRoleUser: {
+                AssumedRoleId: 'offlineContext_assumedRoleId',
+                Arn: 'arn:aws:sts::offlineContext_accountId:assumed-role/LambdaExecution/offlineContext_caller'
+            }
+        })
+      })
+    })
+
     this.log(`Iot broker listening on ports: ${port} (mqtt) and ${httpPort} (http)`)
   }
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ const defaultOpts = {
   port: 1883,
   httpPort: 1884,
   noStart: false,
-  skipCacheInvalidation: false
+  skipCacheInvalidation: false,
+  redisHost: 'localhost',
+  redisPort: 6379,
+  redisDB: 12
 }
 
 class ServerlessIotLocal {
@@ -61,6 +64,15 @@ class ServerlessIotLocal {
                 usage: 'Tells the plugin to skip require cache invalidation. A script reloading tool like Nodemon might then be needed',
                 shortcut: 'c',
               },
+              redisHost: {
+                usage: 'Redis host. Default: localhost',
+              },
+              redisPort: {
+                usage: 'Redis port. Default: 6379',
+              },
+              redisDB: {
+                usage: 'Redis database. Default: 12',
+              },
             }
           }
         }
@@ -97,7 +109,7 @@ class ServerlessIotLocal {
   }
 
   _createMQTTBroker() {
-    const { host, port, httpPort } = this.options
+    const { host, port, httpPort, redisHost, redisPort, redisDB } = this.options
     this.mqttBroker = createMQTTBroker({
       host,
       port,
@@ -105,7 +117,10 @@ class ServerlessIotLocal {
         host,
         port: httpPort,
         bundle: true
-      }
+      },
+      redisHost,
+      redisPort,
+      redisDB
     })
 
     const endpointAddress = `${IP.address()}:${httpPort}`


### PR DESCRIPTION
Improves the describeEndpoint mock (Serverless Offline)

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Iot.html#describeEndpoint-property

Add mocks for getCallerIdentity and assumeRole.

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#assumeRole-property
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#getCallerIdentity-property

Add Support for Redis Host, Port and Database.