### PR TITLE
Modify SQL regex's to be case insensitive

### DIFF
--- a/sql.js
+++ b/sql.js
@@ -1,7 +1,7 @@
 const evalInContext = require('./eval')
 const BASE64_PLACEHOLDER = '*b64'
-const SQL_REGEX = /^SELECT (.*)\s+FROM\s+'([^']+)'\s*(?:WHERE\s(.*))?$/
-const SELECT_PART_REGEX = /^(.*?)(?: as (.*))?$/
+const SQL_REGEX = /^SELECT (.*)\s+FROM\s+'([^']+)'\s*(?:WHERE\s(.*))?$/i
+const SELECT_PART_REGEX = /^(.*?)(?: AS (.*))?$/i
 
 const parseSelect = sql => {
   // if (/\([^)]/.test(sql)) {


### PR DESCRIPTION
Tried to use this, but with an upper-case `AS` in my SQL statement. Took me a bit to figure out why parsing was failing. This just modifies the SQL regex constants to be case-insensitive.