### PR TITLE
Flatten wildcard results

### DIFF
--- a/sql.js
+++ b/sql.js
@@ -61,6 +61,15 @@ const applySelect = ({ select, payload, context }) => {
     const { alias, field } = part
     const key = alias || field
     if (field === '*') {
+      /* 
+       * If there is an alias for the wildcard selector, we want to include the fields in a nested key. 
+       * SELECT * as message, clientid() from 'topic'
+       * { message: { fieldOne: 'value', ...}}
+       *
+       * Otherwise, we want the fields flat in the resulting event object.
+       * SELECT *, clientid() from 'topic'
+       * { fieldOne: 'value', ...}
+       */
       if(alias) {
         event[key] = json
       } else {

--- a/sql.js
+++ b/sql.js
@@ -61,13 +61,8 @@ const applySelect = ({ select, payload, context }) => {
       const { alias, field } = part
       const key = alias || field
       if (field === '*') {
-        if (alias) {
-          event[key] = json
-          continue
-        } else {
-          Object.assign(event, json);
-          continue;
-        }
+        alias ? event[key] = json : Object.assign(event, json);
+        continue
       }
 
     const js = field.replace(BASE64_PLACEHOLDER, payloadReplacement)

--- a/sql.js
+++ b/sql.js
@@ -61,7 +61,11 @@ const applySelect = ({ select, payload, context }) => {
     const { alias, field } = part
     const key = alias || field
     if (field === '*') {
-      alias ? event[key] = json : Object.assign(event, json);
+      if(alias) {
+        event[key] = json
+      } else {
+        Object.assign(event, json)
+      }
       continue
     }
 

--- a/sql.js
+++ b/sql.js
@@ -57,13 +57,13 @@ const applySelect = ({ select, payload, context }) => {
     ? `new Buffer('${payload.toString('base64')}', 'base64')`
     : payload
 
-    for (const part of select) {
-      const { alias, field } = part
-      const key = alias || field
-      if (field === '*') {
-        alias ? event[key] = json : Object.assign(event, json);
-        continue
-      }
+  for (const part of select) {
+    const { alias, field } = part
+    const key = alias || field
+    if (field === '*') {
+      alias ? event[key] = json : Object.assign(event, json);
+      continue
+    }
 
     const js = field.replace(BASE64_PLACEHOLDER, payloadReplacement)
     event[key] = evalInContext(js, context)

--- a/sql.js
+++ b/sql.js
@@ -57,13 +57,18 @@ const applySelect = ({ select, payload, context }) => {
     ? `new Buffer('${payload.toString('base64')}', 'base64')`
     : payload
 
-  for (const part of select) {
-    const { alias, field } = part
-    const key = alias || field
-    if (field === '*') {
-      event[key] = json
-      continue
-    }
+    for (const part of select) {
+      const { alias, field } = part
+      const key = alias || field
+      if (field === '*') {
+        if (alias) {
+          event[key] = json
+          continue
+        } else {
+          Object.assign(event, json);
+          continue;
+        }
+      }
 
     const js = field.replace(BASE64_PLACEHOLDER, payloadReplacement)
     event[key] = evalInContext(js, context)


### PR DESCRIPTION
## Problem Description

When setting up an iot function with a sql statement like:
```
SELECT *, clientid() AS authorizedUserId FROM 'project/topic'
```
If you send a message such as:
```
{
  fieldOne: 'test',
  fieldTwo: 'testTwo'
}
```
The event that will be sent to the handler is:
```
{
  * : {
    fieldOne: 'test',
    fieldTwo: 'testTwo'
  },
  authorizationUserId: undefined
}
```
Using the same sql statement on a live AWS setup generates a message like:
```
{
  fieldOne: 'test',
  fieldTwo: 'testTwo',
  authorizationUserId: undefined
}
```

## Changes Made

Modified `sql.js` to treat a * field with no alias differently than a * with an alias. In the case of no alias, the properties of the JSON object will be assigned directly to the event object. If there is an alias then it will behave as it did previously, and place the JSON object in the event using the alias as the key. This way, a SQL like:
```
SELECT * as message, clientid() AS authorizedUserId FROM 'project/topic'
```
Will still generate:
```
{
  message : {
    fieldOne: 'test',
    fieldTwo: 'testTwo'
  },
  authorizationUserId: undefined
}
```


