### PR TITLE
Don't break if principal() is used in topic query

### DIFF
--- a/eval.js
+++ b/eval.js
@@ -1,7 +1,7 @@
 // TODO: trim(), ltrim(), etc
 
 const evalInContext = (js, context) => {
-  const { clientid, topic } = context
+  const { clientid, topic, principal } = context
   try {
     return eval(js)
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -252,7 +252,8 @@ class ServerlessIotLocal {
             payload: message,
             context: {
               topic: () => topic,
-              clientid: () => clientId
+              clientid: () => clientId,
+              principal: () => {}
             }
           })
 


### PR DESCRIPTION
Currently, using `principal()` inside the topic SQL will cause the plugin to fail, since it doesn't have a principal function to use.

This change does not add full support for principal() since it doesn't return any kind of value, but it does keep the plugin from crashing.