### PR TITLE
Add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/__tests__/eval.test.js
+++ b/__tests__/eval.test.js
@@ -1,0 +1,17 @@
+const evalInContext = require('../eval')
+
+describe('evalInContext', () => {
+  it('evals global variable', () => {
+    global.property = 'property'
+    expect(evalInContext('property', {})).toBe('property')
+  })
+
+  it('evals function in context', () => {
+    const clientid = jest.fn().mockReturnValue('test')
+    expect(evalInContext('clientid()', { clientid })).toBe('test')
+  })
+
+  it('throws error if variable does not exist', () => {
+    expect(() => evalInContext('notHere', {})).toThrowError()
+  })
+})

--- a/__tests__/sql.test.js
+++ b/__tests__/sql.test.js
@@ -1,0 +1,103 @@
+const { parseSelect, applySelect } = require('../sql.js')
+
+describe('parseSelect', () => {
+  it('parses simple SQL correctly', () => {
+    const subject = "SELECT * FROM 'topic'"
+    const results = parseSelect(subject)
+    expect(results.select).toEqual([{ field: '*', alias: undefined }])
+    expect(results.topic).toBe('topic')
+    expect(results.where).toBe(undefined)
+  })
+
+  it('parses lowercase simple SQL correctly', () => {
+    const subject = "select * from 'topic'"
+    const results = parseSelect(subject)
+    expect(results.select).toEqual([{ field: '*', alias: undefined }])
+    expect(results.topic).toBe('topic')
+    expect(results.where).toBe(undefined)
+  })
+
+  it('parses where clause correctly', () => {
+    const subject = "SELECT * FROM 'topic' WHERE name='Bob'"
+    const results = parseSelect(subject)
+    expect(results.select).toEqual([{ field: '*', alias: undefined }])
+    expect(results.topic).toBe('topic')
+    expect(results.where).toBe("name='Bob'")
+  })
+
+  it('parses multiple SELECT properties correctly', () => {
+    const subject = "SELECT name, age, isMale AS gender FROM 'topic'"
+    const results = parseSelect(subject)
+    expect(results.select).toEqual([
+      { field: 'name', alias: undefined},
+      { field: 'age', alias: undefined },
+      { field: 'isMale', alias: 'gender'}
+    ])
+  })
+})
+
+describe('applySelect', () => {
+  describe('Simple select with buffered string handled correctly', () => {
+    const select = [{ field: '*', alias: undefined }]
+    const payload = Buffer.from(JSON.stringify({name: 'Bob'}), 'utf8')
+    const context = {}
+    const event = applySelect({ select, payload, context })
+    expect(event).toEqual({ name: 'Bob' })
+  })
+
+  describe('Simple select with non-JSON handled correctly', () => {
+    const select = [{ field: '*', alias: undefined }]
+    const payload = 'Bob'
+    const context = {}
+    const event = applySelect({ select, payload, context })
+    expect(event).toEqual( 'Bob' )
+  })
+
+  describe('Aliased wildcard with non-JSON handled correctly', () => {
+    const select = [{ field: '*', alias: 'name' }]
+    const payload = 'Bob'
+    const context = {}
+    const event = applySelect({ select, payload, context })
+    expect(event).toEqual({ 'name': 'Bob' })
+  })
+
+  describe('Unaliased wildcard plus function results in flattened output', () => {
+    const select = [
+      { field: '*', alias: undefined },
+      { field: 'clientid()', alias: undefined }
+    ]
+    const clientIdFunc = jest.fn()
+    const payload = Buffer.from(JSON.stringify({name: 'Bob'}), 'utf8')
+    const context = { clientid: clientIdFunc }
+    const event = applySelect({ select, payload, context })
+    expect(clientIdFunc).toHaveBeenCalledTimes(1)
+    expect(event).toEqual({ name: 'Bob' })
+  })
+
+  describe('Aliased wildcard plus function results in nested output', () => {
+    const select = [
+      { field: '*', alias: 'message' },
+      { field: 'clientid()', alias: undefined }
+    ]
+    const clientIdFunc = jest.fn()
+    const payload = Buffer.from(JSON.stringify({name: 'Bob'}), 'utf8')
+    const context = { clientid: clientIdFunc }
+    const event = applySelect({ select, payload, context })
+    expect(clientIdFunc).toHaveBeenCalledTimes(1)
+    expect(event).toEqual({ message: { name: 'Bob' } })
+  })
+
+  describe('Function results are appeneded to output', () => {
+    const select = [
+      { field: '*', alias: 'message' },
+      { field: 'clientid()', alias: undefined }
+    ]
+    const clientIdFunc = jest.fn().mockReturnValue('12345')
+    const payload = Buffer.from(JSON.stringify({name: 'Bob'}), 'utf8')
+    const context = { clientid: clientIdFunc }
+    const event = applySelect({ select, payload, context })
+    expect(clientIdFunc).toHaveBeenCalledTimes(1)
+    expect(event).toEqual({ message: { name: 'Bob' }, 'clientid()': '12345' })
+  })
+
+})

--- a/__tests__/sql.test.js
+++ b/__tests__/sql.test.js
@@ -90,14 +90,14 @@ describe('applySelect', () => {
   describe('Function results are appeneded to output', () => {
     const select = [
       { field: '*', alias: 'message' },
-      { field: 'clientid()', alias: undefined }
+      { field: 'clientid()', alias: 'theClientId' }
     ]
     const clientIdFunc = jest.fn().mockReturnValue('12345')
     const payload = Buffer.from(JSON.stringify({name: 'Bob'}), 'utf8')
     const context = { clientid: clientIdFunc }
     const event = applySelect({ select, payload, context })
     expect(clientIdFunc).toHaveBeenCalledTimes(1)
-    expect(event).toEqual({ message: { name: 'Bob' }, 'clientid()': '12345' })
+    expect(event).toEqual({ message: { name: 'Bob' }, 'theClientId': '12345' })
   })
 
 })

--- a/__tests__/sql.test.js
+++ b/__tests__/sql.test.js
@@ -26,12 +26,12 @@ describe('parseSelect', () => {
   })
 
   it('parses multiple SELECT properties correctly', () => {
-    const subject = "SELECT name, age, isMale AS gender FROM 'topic'"
+    const subject = "SELECT name, age, maleOrFemale AS gender FROM 'topic'"
     const results = parseSelect(subject)
     expect(results.select).toEqual([
       { field: 'name', alias: undefined},
       { field: 'age', alias: undefined },
-      { field: 'isMale', alias: 'gender'}
+      { field: 'maleOrFemale', alias: 'gender'}
     ])
   })
 })

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": "https://github.com/tradle/serverless-iot-local",
   "author": "mvayngrib",
   "license": "MIT",
+  "scripts": {
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
   "dependencies": {
     "aws-sdk-mock": "^1.7.0",
     "ip": "^1.1.5",
@@ -18,5 +22,8 @@
   "peerDependencies": {
     "aws-sdk": "*",
     "serverless-offline": "*"
+  },
+  "devDependencies": {
+    "jest": "^22.4.3"
   }
 }


### PR DESCRIPTION
I created some of these during while working on other stuff and figured I'd clean them up and send them your way. Not sure if Jest is your tool of choice for testing, but it seemed easiest.

To run tests: `yarn test` or `npm test`
To run coverage: `yarn coverage` or `npm coverage`

Since `eval.encode` is never exported and never used it doesn't get covered by the tests.